### PR TITLE
Fixed blockquote quote symbol behaviour in dark mode

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -73,7 +73,8 @@ blockquote:before {
     left: 100px;
     content: "\f10d";
     font-size: 200px;
-    color: rgba(0, 0, 0, 0.1);
+    color: var(--primary);
+    opacity: 0.1;
 }
 
 blockquote p {


### PR DESCRIPTION
## Summary
Fixed blockquote quote symbol behaviour in dark mode

## Issue link(s)
#35 

## Changes
* Changed color of the quote symbol to use the color variable to support auto-switch when a switch in mode occurs

## Checklist
- [x]  This PR represents a single feature, fix, or change
- [x]  These changes have been tested locally
- [ ]  Updated relevant documentation (feature wikis, README)
- [x]  Screenshots added for UI changes

<img width="1154" alt="Screenshot 2020-04-26 at 1 15 40 AM" src="https://user-images.githubusercontent.com/35839390/80289353-86b4f000-875b-11ea-8a92-3e11d46c1a13.png">
